### PR TITLE
config: add configuration for PR merge method

### DIFF
--- a/.spr.yml
+++ b/.spr.yml
@@ -5,3 +5,4 @@ requireChecks: true
 requireApproval: true
 githubRemote: origin
 githubBranch: master
+mergeMethod: rebase

--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,8 @@ MERGED #60 Feature 3
 
 To merge only part of the stack use the **--upto** flag with the top pull request number in the stack that you would like to merge.
 
+By default merges are done using the rebase merge method, this can be changed using the mergeMethod configuration.
+
 ```shell
 > git spr merge --upto 59
 MERGED #58 Feature 1
@@ -160,6 +162,7 @@ User specific configuration is saved to .spr.yml in the user home directory.
 | githubRemote        | str  | origin     | github remote name to use                                      |
 | githubBranch        | str  | master     | github branch for pull request target                          |
 | githubHost          | str  | github.com | github host, can be updated for github enterprise usecase      |
+| mergeMethod         | str  | rebase     | merge method, valid values: [rebase, squash, merge]            |
 
 | User Config         | Type | Default | Description                                                       |
 | ------------------- | ---- | ------- | ----------------------------------------------------------------- |


### PR DESCRIPTION
The GitHub pull request API support squash, rebase, and merge. As
explored in issue #195, with signed commits required on the target
branch, it's not possible to use the rebase due to a known GitHub
implementation issue.

This change adds a new per-repo string configuration attribute,
`mergeMethod`, `"rebase"` by default. The current behaviour is captured by
this default value.

**Issue references**: 

 - #195---

**Stack**:
- #2
- #1 ⮜


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*